### PR TITLE
chore: update tapsellplus to `2.2.0`

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -63,7 +63,7 @@ dependencies {
     implementation 'androidx.recyclerview:recyclerview:1.3.0'
 
     // for TapsellPlus
-    implementation 'ir.tapsell.plus:tapsell-plus-sdk-android:2.1.9'
+    implementation 'ir.tapsell.plus:tapsell-plus-sdk-android:2.2.0'
 
     //for adMob
     implementation 'com.google.android.gms:play-services-ads:21.5.0'


### PR DESCRIPTION
Fixed https://github.com/tapsellorg/TapsellPlusSDK-AndroidSample/issues/68