### PR TITLE
release: update sdk to 2.3.3

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -66,7 +66,7 @@ dependencies {
     implementation 'androidx.recyclerview:recyclerview:1.3.2'
 
     // for TapsellPlus
-    implementation 'ir.tapsell.plus:tapsell-plus-sdk-android:2.3.2'
+    implementation 'ir.tapsell.plus:tapsell-plus-sdk-android:2.3.3'
 
     //for adMob
     implementation 'com.google.android.gms:play-services-ads:22.6.0'

--- a/build.gradle
+++ b/build.gradle
@@ -4,11 +4,10 @@ buildscript {
 
     repositories {
         mavenCentral()
-        jcenter()
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:8.7.2'
+        classpath 'com.android.tools.build:gradle:8.13.0'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.10.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.3-bin.zip


### PR DESCRIPTION
### 2.3.3 (09 Sep 2025)

- Update tapsell sdk to `v4.9.13`.
- Migrated Android Media Player to `ExoPlayer`
- Fixed ANR issue in Rewarded and Interstitial videos ads.
- Fixed showing close button in interstitial banners in rotation changes.
- Fixed back navigation issue by isolating predictive back-gesture handling to AdActivity to avoid
  side-effect on global back navigation